### PR TITLE
Added support for CPU devices

### DIFF
--- a/Example.py
+++ b/Example.py
@@ -10,7 +10,7 @@ device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
 student_ldm_ckpt_path:str = './ModelWeights/student_ldm.pth'
 sr_vocoder_ckpt_path:str = './ModelWeights/sr_vocoder.pth'
 vae_ckpt_path:str = './ModelWeights/vae.pth'
-flashsr = FlashSR( student_ldm_ckpt_path, sr_vocoder_ckpt_path, vae_ckpt_path)
+flashsr = FlashSR( student_ldm_ckpt_path, sr_vocoder_ckpt_path, vae_ckpt_path, device)
 flashsr = flashsr.to(device)
 
 audio_path:str = './Assets/ExampleInput/music.wav'

--- a/FlashSR/FlashSR.py
+++ b/FlashSR/FlashSR.py
@@ -18,6 +18,7 @@ class FlashSR(DDPM):
             student_ldm_ckpt_path:str,
             sr_vocoder_ckpt_path:str,
             autoencoder_ckpt_path:str,
+            device:str,
             model_output_type:str = 'v_prediction',
             beta_schedule_type:str = 'cosine',
             **kwargs
@@ -31,7 +32,7 @@ class FlashSR(DDPM):
         self.vae = VAEWrapper(autoencoder_ckpt_path)
 
         self.sr_vocoder = SRVocoder()
-        sr_vocoder_state_dict = torch.load(sr_vocoder_ckpt_path)
+        sr_vocoder_state_dict = torch.load(sr_vocoder_ckpt_path, map_location=torch.device(device))
         self.sr_vocoder.load_state_dict(sr_vocoder_state_dict)
 
     def forward(self, 


### PR DESCRIPTION
The following error appeared during inference on the CPU device:
```
RuntimeError: Attempting to deserialize object on a CUDA device but torch.cuda.is_available () is False. If you are running on a CPU-only machine, please use torch.load with map_location = torch.device ('cpu') to map your storages to the CPU.
```
This PR fixes it.